### PR TITLE
fix(components/TronWrap/index.js): fix solidityNode request typo

### DIFF
--- a/src/components/TronWrap/index.js
+++ b/src/components/TronWrap/index.js
@@ -511,7 +511,7 @@ function init(options, extraOptions = {}) {
   };
 
   tronWrap.solidityNode.request = function (url, payload = {}, method = 'get') {
-    return tronWrap.fullNode._request(url, payload, method).then(data => {
+    return tronWrap.solidityNode._request(url, payload, method).then(data => {
       tronWrap._getConsoleLog(url, data);
       return data;
     });


### PR DESCRIPTION
Hello! I added a typo fix in `tronWrap.solidityNode.request` method which made requests to fullNode instead of solidityNode