### PR TITLE
Release/4.10.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,11 @@
 {
   "presets": [
-    "@babel/preset-env"
-  ],
-  "plugins": [
-    ["@babel/plugin-transform-runtime",
+    [
+      "@babel/preset-env",
       {
-        "regenerator": true
+        "targets": {
+          "node": "18"
+        }
       }
     ]
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ vite.config.ts.timestamp-*
 
 # TronBox build directory
 build
+
+# TronBox console history
+.console_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+**4.10.0**
+
+### Features
+
+- Added support for Tron Solidity compilers 0.8.27, 0.8.28 and 0.8.29; new projects default to 0.8.29
+- `console` now persists REPL history across sessions in `.console_history` under the project root
+
+### Bug Fixes
+
+- Fixed `migrate` skipping pending migrations when the last completed migration file has been renumbered or removed
+- Fixed array-form `deployer.deploy` deploying contracts concurrently instead of sequentially
+- Fixed transaction option handling when deploying and calling contracts
+- Fixed `test` dropping user-configured mocha `reporterOptions`
+- Fixed `console` ignoring artifact-loading errors; it now loads only `.json` artifacts and exits on a corrupt one
+- Fixed `flatten` duplicating sources included through different import paths
+- Fixed `flatten` dropping trailing content when stripping import lines
+- Fixed `unbox` masking download and extraction errors
+- Fixed calling contract functions named `name` or `length` on deployed contract instances
+- Fixed unknown commands that match built-in JavaScript property names not being rejected
+
+### Dependencies
+
+- Upgraded `tronweb` to 6.4.0
+- Upgraded `axios` to 1.19.0
+
 **4.9.0**
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ TronBox is a development framework and testing environment for smart contracts o
 With TronBox, you get:
 
 - Built-in smart contract compilation, linking, deployment, and binary management.
-- An external script runner that executes scripts within a TronBox environment.
 - An interactive console for direct contract communication.
 - Automated contract testing for rapid development.
 - A scriptable, extensible deployment & migrations framework.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "mocha": "11.7.4",
         "node-dir": "0.1.17",
         "source-map-support": "0.5.21",
-        "tronweb": "6.3.0",
+        "tronweb": "6.4.0",
         "yargs": "15.4.1",
         "yauzl": "3.4.0"
       },
@@ -5336,13 +5336,13 @@
       }
     },
     "node_modules/tronweb": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-6.3.0.tgz",
-      "integrity": "sha512-5CAjDO4/KfymgjKFgnXgfKKQp0xgOn8otCBYjgYAEIpLZDKNAk14Z0dDeg0UqYuceCiyMHjW7a19Rsz8EmhAOw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-6.4.0.tgz",
+      "integrity": "sha512-WyrjHKN6YSnV/Dvc4cdULDyXVKJfj4bqQ/8dib6FlOaQ1T/EiOjLtOx24hDgcn8lY/iVMy4Axchzurk1wGcRJg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.26.10",
-        "axios": "1.15.0",
+        "axios": "1.18.0",
         "bignumber.js": "9.1.2",
         "ethereum-cryptography": "2.2.1",
         "ethers": "6.13.5",
@@ -5357,6 +5357,18 @@
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
       "license": "MIT"
+    },
+    "node_modules/tronweb/node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/tronweb/node_modules/ethers": {
       "version": "6.13.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4081,9 +4081,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tronbox",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tronbox",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "dependencies": {
         "@solidity-parser/parser": "0.20.2",
         "ajv": "6.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
       "devDependencies": {
         "@babel/cli": "7.28.3",
         "@babel/core": "7.28.3",
-        "@babel/plugin-transform-runtime": "7.28.3",
         "@babel/preset-env": "7.28.3",
         "eslint": "9.39.1",
         "eslint-plugin-n": "17.23.1",
@@ -1344,27 +1343,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
-      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "babel-plugin-polyfill-corejs2": "^0.4.14",
-        "babel-plugin-polyfill-corejs3": "^0.13.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.5",
-        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@solidity-parser/parser": "0.20.2",
         "ajv": "6.14.0",
         "async": "2.6.4",
-        "axios": "1.16.1",
+        "axios": "1.19.0",
         "chai": "4.1.2",
         "chalk": "2.4.2",
         "debug": "3.2.7",
@@ -2364,13 +2364,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -2460,9 +2460,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4081,9 +4081,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -4457,9 +4457,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "11.7.4",
     "node-dir": "0.1.17",
     "source-map-support": "0.5.21",
-    "tronweb": "6.3.0",
+    "tronweb": "6.4.0",
     "yargs": "15.4.1",
     "yauzl": "3.4.0"
   },
@@ -58,7 +58,6 @@
       "serialize-javascript": "7.0.5"
     },
     "tronweb": {
-      "axios": "1.16.1",
       "ws": "8.21.0"
     }
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@solidity-parser/parser": "0.20.2",
     "ajv": "6.14.0",
     "async": "2.6.4",
-    "axios": "1.16.1",
+    "axios": "1.19.0",
     "chai": "4.1.2",
     "chalk": "2.4.2",
     "debug": "3.2.7",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "devDependencies": {
     "@babel/cli": "7.28.3",
     "@babel/core": "7.28.3",
-    "@babel/plugin-transform-runtime": "7.28.3",
     "@babel/preset-env": "7.28.3",
     "eslint": "9.39.1",
     "eslint-plugin-n": "17.23.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tronbox",
   "namespace": "tronprotocol",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "TronBox - Simple development framework for Tron",
   "keywords": [
     "TronBox",

--- a/sample-projects/javascript-metacoin/gitignore
+++ b/sample-projects/javascript-metacoin/gitignore
@@ -140,3 +140,6 @@ dist
 
 # TronBox build directory
 build
+
+# TronBox console history
+.console_history

--- a/sample-projects/javascript-metacoin/tronbox-config.js
+++ b/sample-projects/javascript-metacoin/tronbox-config.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.28',
+      version: '0.8.29',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript-metacoin/tronbox-config.js
+++ b/sample-projects/javascript-metacoin/tronbox-config.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.26',
+      version: '0.8.27',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript-metacoin/tronbox-config.js
+++ b/sample-projects/javascript-metacoin/tronbox-config.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.27',
+      version: '0.8.28',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript-metacoin/tronbox-evm-config.js
+++ b/sample-projects/javascript-metacoin/tronbox-evm-config.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.28',
+      version: '0.8.29',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript-metacoin/tronbox-evm-config.js
+++ b/sample-projects/javascript-metacoin/tronbox-evm-config.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.27',
+      version: '0.8.28',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript-metacoin/tronbox-evm-config.js
+++ b/sample-projects/javascript-metacoin/tronbox-evm-config.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.26',
+      version: '0.8.27',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript/gitignore
+++ b/sample-projects/javascript/gitignore
@@ -140,3 +140,6 @@ dist
 
 # TronBox build directory
 build
+
+# TronBox console history
+.console_history

--- a/sample-projects/javascript/tronbox-config.js
+++ b/sample-projects/javascript/tronbox-config.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.28',
+      version: '0.8.29',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript/tronbox-config.js
+++ b/sample-projects/javascript/tronbox-config.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.26',
+      version: '0.8.27',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript/tronbox-config.js
+++ b/sample-projects/javascript/tronbox-config.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.27',
+      version: '0.8.28',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript/tronbox-evm-config.js
+++ b/sample-projects/javascript/tronbox-evm-config.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.28',
+      version: '0.8.29',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript/tronbox-evm-config.js
+++ b/sample-projects/javascript/tronbox-evm-config.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.27',
+      version: '0.8.28',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/sample-projects/javascript/tronbox-evm-config.js
+++ b/sample-projects/javascript/tronbox-evm-config.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: '0.8.26',
+      version: '0.8.27',
       // An object with the same schema as the settings entry in the Input JSON.
       // See https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
       settings: {

--- a/src/components/Box/lib/utils/download.js
+++ b/src/components/Box/lib/utils/download.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const os = require('os');
 const path = require('path');
+const { pipeline } = require('stream/promises');
 const fs = require('fs-extra');
 const yauzl = require('yauzl');
 
@@ -17,9 +18,7 @@ function parseParams(params) {
 }
 
 function streamToFile(stream, file) {
-  return new Promise((resolve, reject) => {
-    stream.pipe(fs.createWriteStream(file)).on('close', resolve).on('error', reject);
-  });
+  return pipeline(stream, fs.createWriteStream(file));
 }
 
 function extractZip(zipFile, outputDir) {
@@ -70,13 +69,10 @@ function extractZip(zipFile, outputDir) {
           fs.ensureDir(path.dirname(file), err => {
             if (err) return fail(err);
 
-            const writeStream = fs.createWriteStream(file);
-            readStream.pipe(writeStream);
-            writeStream.on('close', () => {
+            pipeline(readStream, fs.createWriteStream(file)).then(() => {
               pending--;
               maybeFinish();
-            });
-            writeStream.on('error', fail);
+            }, fail);
           });
         });
         zipfile.readEntry();
@@ -109,6 +105,8 @@ module.exports = async function downloadRepo(params, dir) {
     const extractedFolder = await extractZip(zipFile, tmpDir);
     await fs.move(path.join(tmpDir, extractedFolder), targetDir, { overwrite: true });
   } finally {
-    await fs.remove(tmpDir);
+    try {
+      fs.removeSync(tmpDir);
+    } catch (e) {}
   }
 };

--- a/src/components/Contract/contract.js
+++ b/src/components/Contract/contract.js
@@ -267,12 +267,22 @@ Contract._static_methods = {
                 f.call = f;
                 return f;
               };
+
               if (!self.hasOwnProperty(item.name)) {
                 self[item.name] = createWrapper(item.name);
               }
 
               if (!self.hasOwnProperty(functionSelector)) {
                 self[functionSelector] = createWrapper(functionSelector);
+              }
+
+              if (functionSelector === 'name()' || functionSelector === 'length()') {
+                Object.defineProperty(self, item.name, {
+                  value: createWrapper(functionSelector),
+                  writable: true,
+                  enumerable: true,
+                  configurable: true
+                });
               }
             }
           }

--- a/src/components/Contract/contract.js
+++ b/src/components/Contract/contract.js
@@ -268,11 +268,11 @@ Contract._static_methods = {
                 return f;
               };
 
-              if (!self.hasOwnProperty(item.name)) {
+              if (!Object.prototype.hasOwnProperty.call(self, item.name)) {
                 self[item.name] = createWrapper(item.name);
               }
 
-              if (!self.hasOwnProperty(functionSelector)) {
+              if (!Object.prototype.hasOwnProperty.call(self, functionSelector)) {
                 self[functionSelector] = createWrapper(functionSelector);
               }
 

--- a/src/components/Deployer/src/actions/deploymany.js
+++ b/src/components/Deployer/src/actions/deploymany.js
@@ -2,11 +2,13 @@ const deploy = require('./deploy');
 
 module.exports = function (arr, deployer) {
   return function () {
-    const deployments = arr.map(function (entry) {
-      const [contract, ...args] = Array.isArray(entry) ? entry : [entry];
-      return deploy(contract, args, deployer)();
-    });
-
-    return Promise.all(deployments);
+    return arr.reduce(function (promise, entry) {
+      return promise.then(function (instances) {
+        const [contract, ...args] = Array.isArray(entry) ? entry : [entry];
+        return deploy(contract, args, deployer)().then(function (instance) {
+          return instances.concat(instance);
+        });
+      });
+    }, Promise.resolve([]));
   };
 };

--- a/src/components/Flatten/index.js
+++ b/src/components/Flatten/index.js
@@ -69,25 +69,32 @@ function compareDependencyPaths(a, b) {
   return a.localeCompare(b);
 }
 
+function getAbsolutePath(importPath, workingDirectory) {
+  const location = path.isAbsolute(importPath) ? importPath : path.join(workingDirectory, 'node_modules', importPath);
+  return path.resolve(location).replace(/\\/g, '/');
+}
+
 async function getSortedFilePaths(entryPoints, resolver, config) {
   const sortedFiles = [];
   const visitedFiles = new Set();
   const processing = new Set();
   const resolvedCache = new Map();
 
-  async function visit(filePath) {
+  async function visit(importPath) {
+    const filePath = getAbsolutePath(importPath, config.working_directory);
+
     if (visitedFiles.has(filePath)) return;
 
     if (processing.has(filePath)) {
       throw new Error(
-        'There is a cycle in the dependency' + " graph, can't compute topological ordering. Files:\n\t" + filePath
+        'There is a cycle in the dependency' + " graph, can't compute topological ordering. Files:\n\t" + importPath
       );
     }
 
     processing.add(filePath);
 
-    const resolved = await resolve(filePath, resolver, config);
-    resolvedCache.set(filePath, resolved);
+    const resolved = await resolve(importPath, resolver, config);
+    resolvedCache.set(importPath, resolved);
     const dependencies = getDependencies(resolved.filePath, resolved.fileContents).sort(compareDependencyPaths);
 
     for (const dependency of dependencies) {
@@ -96,7 +103,7 @@ async function getSortedFilePaths(entryPoints, resolver, config) {
 
     processing.delete(filePath);
     visitedFiles.add(filePath);
-    sortedFiles.push(filePath);
+    sortedFiles.push(importPath);
   }
 
   for (const entryPoint of [...entryPoints].sort()) {

--- a/src/components/Flatten/index.js
+++ b/src/components/Flatten/index.js
@@ -7,7 +7,6 @@ const pkg = require('../../lib/pkg');
 
 const SPDX_LICENSES_REGEX = /^(?:\/\/|\/\*)\s*SPDX-License-Identifier:\s*([a-zA-Z\d+.-]+).*/gm;
 const PRAGMA_DIRECTIVES_REGEX = /^(?: |\t)*(pragma\s*abicoder\s*v(1|2)|pragma\s*experimental\s*ABIEncoderV2)\s*;/gim;
-const IMPORT_SOLIDITY_REGEX = /^\s*import(\s+)[\s\S]*?;\s*$/gm;
 
 async function resolve(importPath, resolver, config) {
   try {
@@ -36,16 +35,18 @@ function getDirPath(filePath) {
   return filePath.substring(0, Math.max(index1, index2));
 }
 
-function getDependencies(filePath, fileContents) {
+function getImports(filePath, fileContents) {
   try {
-    const ast = parser.parse(fileContents);
-    const imports = [];
+    const ast = parser.parse(fileContents, { range: true });
+    const dependencies = [];
+    const importRanges = [];
     parser.visit(ast, {
       ImportDirective: function (node) {
-        imports.push(getNormalizedDependencyPath(node.path, filePath));
+        dependencies.push(getNormalizedDependencyPath(node.path, filePath));
+        importRanges.push(node.range);
       }
     });
-    return imports;
+    return { dependencies, importRanges };
   } catch (error) {
     throw new Error('Could not parse ' + filePath + ' for extracting its imports: ' + error);
   }
@@ -94,8 +95,11 @@ async function getSortedFilePaths(entryPoints, resolver, config) {
     processing.add(filePath);
 
     const resolved = await resolve(importPath, resolver, config);
+    const { dependencies, importRanges } = getImports(resolved.filePath, resolved.fileContents);
+    dependencies.sort(compareDependencyPaths);
+    resolved.importRanges = importRanges;
+
     resolvedCache.set(importPath, resolved);
-    const dependencies = getDependencies(resolved.filePath, resolved.fileContents).sort(compareDependencyPaths);
 
     for (const dependency of dependencies) {
       await visit(dependency);
@@ -123,8 +127,8 @@ function fileNameToGlobalName(fileName, projectRoot) {
 }
 
 async function printFileContents(files, log) {
-  const parts = files.map(({ file, content, packageInfo }) => {
-    let normalizedText = getTextWithoutImports(content);
+  const parts = files.map(({ file, content, packageInfo, importRanges }) => {
+    let normalizedText = getTextWithoutImports(content, importRanges);
     normalizedText = commentOutLicenses(normalizedText);
     normalizedText = commentOutPragmaAbicoderDirectives(normalizedText);
 
@@ -222,8 +226,22 @@ function getPragmaAbicoderDirectiveHeader(pragmaDirective) {
   return pragmaDirective === '' ? '' : `\n\n${pragmaDirective};`;
 }
 
-function getTextWithoutImports(fileContent) {
-  return fileContent.replace(IMPORT_SOLIDITY_REGEX, '').trim();
+function getTextWithoutImports(fileContent, importRanges) {
+  // Remove each import [start, semicolon] plus trailing whitespace and the
+  // newline so the line collapses; a trailing comment stays.
+  const removals = importRanges.map(([start, semicolon]) => {
+    let end = semicolon + 1;
+    while (fileContent[end] === ' ' || fileContent[end] === '\t') end++;
+    if (fileContent[end] === '\r') end++;
+    if (fileContent[end] === '\n') end++;
+    return [start, end];
+  });
+
+  let result = fileContent;
+  for (const [start, end] of removals.sort((a, b) => b[0] - a[0])) {
+    result = result.slice(0, start) + result.slice(end);
+  }
+  return result.trim();
 }
 
 function commentOutLicenses(fileContent) {
@@ -254,7 +272,8 @@ const Flatten = {
           return {
             file: fileNameToGlobalName(file, projectRoot),
             content: resolved.fileContents,
-            packageInfo: resolved.packageInfo
+            packageInfo: resolved.packageInfo,
+            importRanges: resolved.importRanges
           };
         });
 

--- a/src/components/Migrate/index.js
+++ b/src/components/Migrate/index.js
@@ -260,14 +260,14 @@ const Migrate = {
         if (err) return callback(err);
 
         while (migrations.length > 0) {
-          if (migrations[0].number >= number) {
+          if (migrations[0].number > number) {
             break;
           }
 
           migrations.shift();
         }
 
-        callback(null, migrations.length > 1 || (migrations.length && number === 0));
+        callback(null, migrations.length > 0);
       });
     });
   }

--- a/src/components/Resolver/intercept.js
+++ b/src/components/Resolver/intercept.js
@@ -1,6 +1,6 @@
 function ResolverIntercept(resolver) {
   this.resolver = resolver;
-  this.cache = {};
+  this.cache = Object.create(null);
 }
 
 ResolverIntercept.prototype.require = function (import_path) {

--- a/src/components/Resolver/intercept.js
+++ b/src/components/Resolver/intercept.js
@@ -19,9 +19,6 @@ ResolverIntercept.prototype.require = function (import_path) {
 
   this.cache[import_path] = resolved;
 
-  // The chain may be slow to accept transactions; never time out the wait.
-  resolved.synchronization_timeout = 0;
-
   return resolved;
 };
 

--- a/src/components/TronSolc.js
+++ b/src/components/TronSolc.js
@@ -96,8 +96,6 @@ You are using version ${chalk.yellow(compilerVersion)}, which is not supported.`
   const soljsonPath = path.join(solcDir, `soljson_v${compilerVersion}.js`);
 
   if (!fs.existsSync(soljsonPath)) {
-    const cliPath = process.argv[1] || pkg.name;
-
     options.logger.log(`Fetching ${options.evm ? 'Ethereum' : 'Tron'} Solidity compiler version ${compilerVersion}...`);
     try {
       const args = ['--download-compiler', compilerVersion];
@@ -105,7 +103,7 @@ You are using version ${chalk.yellow(compilerVersion)}, which is not supported.`
         args.push('--evm');
       }
 
-      const result = execFileSync(process.execPath, [cliPath, ...args], {
+      const result = execFileSync(process.execPath, [process.argv[1], ...args], {
         env: { ...process.env, FORCE_COLOR: '1' },
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe']

--- a/src/components/TronSolc.js
+++ b/src/components/TronSolc.js
@@ -6,7 +6,7 @@ const fs = require('fs-extra');
 const homedir = require('homedir');
 const pkg = require('../lib/pkg');
 
-const maxVersion = '0.8.26';
+const maxVersion = '0.8.27';
 
 function compareVersions(version1, version2) {
   const v1Parts = version1.split('.').map(Number);

--- a/src/components/TronSolc.js
+++ b/src/components/TronSolc.js
@@ -6,7 +6,7 @@ const fs = require('fs-extra');
 const homedir = require('homedir');
 const pkg = require('../lib/pkg');
 
-const maxVersion = '0.8.27';
+const maxVersion = '0.8.28';
 
 function compareVersions(version1, version2) {
   const v1Parts = version1.split('.').map(Number);

--- a/src/components/TronSolc.js
+++ b/src/components/TronSolc.js
@@ -6,7 +6,7 @@ const fs = require('fs-extra');
 const homedir = require('homedir');
 const pkg = require('../lib/pkg');
 
-const maxVersion = '0.8.28';
+const maxVersion = '0.8.29';
 
 function compareVersions(version1, version2) {
   const v1Parts = version1.split('.').map(Number);

--- a/src/components/TronWrap/index.js
+++ b/src/components/TronWrap/index.js
@@ -67,6 +67,13 @@ function validateNodeUrl(nodeUrl, configKey = 'node URL', logger = {}) {
   }
 }
 
+function resolveDeployAssetOption(txOptions, networkConfig, key) {
+  if (Object.prototype.hasOwnProperty.call(txOptions, key)) {
+    return txOptions[key];
+  }
+  return networkConfig[key];
+}
+
 function filterNetworkConfig(options) {
   const userFeePercentage =
     typeof options.userFeePercentage === 'number'
@@ -284,9 +291,9 @@ function init(options, extraOptions = {}) {
       {
         bytecode: txOptions.data,
         feeLimit: txOptions.feeLimit || this.networkConfig.feeLimit,
-        callValue: txOptions.callValue || this.networkConfig.callValue,
-        tokenId: txOptions.tokenId || this.networkConfig.tokenId,
-        tokenValue: txOptions.tokenValue || this.networkConfig.tokenValue,
+        callValue: resolveDeployAssetOption(txOptions, this.networkConfig, 'callValue'),
+        tokenId: resolveDeployAssetOption(txOptions, this.networkConfig, 'tokenId'),
+        tokenValue: resolveDeployAssetOption(txOptions, this.networkConfig, 'tokenValue'),
         userFeePercentage,
         originEnergyLimit,
         abi: txOptions.abi,

--- a/src/components/TronWrap/index.js
+++ b/src/components/TronWrap/index.js
@@ -285,6 +285,8 @@ function init(options, extraOptions = {}) {
         bytecode: txOptions.data,
         feeLimit: txOptions.feeLimit || this.networkConfig.feeLimit,
         callValue: txOptions.callValue || this.networkConfig.callValue,
+        tokenId: txOptions.tokenId || this.networkConfig.tokenId,
+        tokenValue: txOptions.tokenValue || this.networkConfig.tokenValue,
         userFeePercentage,
         originEnergyLimit,
         abi: txOptions.abi,

--- a/src/components/TronWrap/index.js
+++ b/src/components/TronWrap/index.js
@@ -557,7 +557,7 @@ function init(options, extraOptions = {}) {
   tronWrap._evmDeployContract = async function (txOptions, callback) {
     const opt = {
       from: txOptions.from || tronWrap._ethers_accounts[0],
-      gas: txOptions.gas || txOptions.gasLimit || this.networkConfig.gas,
+      gasLimit: txOptions.gas || txOptions.gasLimit || this.networkConfig.gas,
       gasPrice: txOptions.gasPrice || this.networkConfig.gasPrice,
       maxPriorityFeePerGas: txOptions.maxPriorityFeePerGas || this.networkConfig.maxPriorityFeePerGas,
       maxFeePerGas: txOptions.maxFeePerGas || this.networkConfig.maxFeePerGas,
@@ -618,7 +618,7 @@ function init(options, extraOptions = {}) {
     const { methodArgs } = txOptions;
     const opt = {
       from: methodArgs.from || tronWrap._ethers_accounts[0],
-      gas: methodArgs.gas || methodArgs.gasLimit || this.networkConfig.gas,
+      gasLimit: methodArgs.gas || methodArgs.gasLimit || this.networkConfig.gas,
       gasPrice: methodArgs.gasPrice || this.networkConfig.gasPrice,
       maxPriorityFeePerGas: methodArgs.maxPriorityFeePerGas || this.networkConfig.maxPriorityFeePerGas,
       maxFeePerGas: methodArgs.maxFeePerGas || this.networkConfig.maxFeePerGas,

--- a/src/lib/command.js
+++ b/src/lib/command.js
@@ -39,7 +39,7 @@ Command.prototype.getCommand = function (cmds) {
 
   const input = argv._[0];
 
-  if (!this.commands[input]) return null;
+  if (!Object.prototype.hasOwnProperty.call(this.commands, input)) return null;
 
   return {
     name: input,

--- a/src/lib/console.js
+++ b/src/lib/console.js
@@ -67,10 +67,7 @@ Console.prototype.start = function (callback) {
   this.options.repl = this.repl;
 
   this.provision(function (err, abstractions) {
-    if (err) {
-      self.options.logger.log('Unexpected error: Cannot provision contracts while instantiating the console.');
-      self.options.logger.log(err.stack || err.message || err);
-    }
+    if (err) return callback(err);
 
     self.repl.start({
       prompt: 'tronbox(' + self.options.network + ')> ',
@@ -99,7 +96,7 @@ Console.prototype.provision = function (callback) {
     }
 
     const promises = [];
-    files = files || [];
+    files = (files || []).filter(file => path.extname(file) === '.json');
 
     files.forEach(function (file) {
       promises.push(

--- a/src/lib/repl.js
+++ b/src/lib/repl.js
@@ -1,4 +1,5 @@
 const repl = require('repl');
+const path = require('path');
 const { expect } = require('./utils');
 const async = require('async');
 const EventEmitter = require('events');
@@ -42,6 +43,8 @@ ReplManager.prototype.start = function (options) {
       prompt: currentContext.prompt,
       eval: this.interpret.bind(this)
     });
+
+    this.repl.setupHistory(path.join(this.options.working_directory, '.console_history'), function () {});
 
     this.repl.on('exit', function () {
       // If we exit for some reason, call done functions for good measure

--- a/src/lib/test.js
+++ b/src/lib/test.js
@@ -93,7 +93,8 @@ const Test = {
     const mochaConfig = config.mocha || {};
 
     mochaConfig.reporterOptions = {
-      maxDiffSize: 0
+      maxDiffSize: 0,
+      ...mochaConfig.reporterOptions
     };
 
     // If the command line overrides color usage, use that.

--- a/test/compile.matrix.test.js
+++ b/test/compile.matrix.test.js
@@ -42,12 +42,14 @@ const versions = fetchVersions();
 describe('full Tron compiler matrix', function () {
   this.timeout(180_000);
 
-  it('list.json newest version equals TronSolc.maxVersion', () => {
-    expect(versions[versions.length - 1]).to.equal(maxVersion);
-  });
+  describe('version list', () => {
+    it('list.json newest version equals TronSolc.maxVersion', () => {
+      expect(versions[versions.length - 1]).to.equal(maxVersion);
+    });
 
-  it('matrix is non-empty', () => {
-    expect(versions.length).to.be.greaterThan(0);
+    it('matrix is non-empty', () => {
+      expect(versions.length).to.be.greaterThan(0);
+    });
   });
 
   describe('every supported version', () => {

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -3,12 +3,12 @@
 const { expect } = require('chai');
 const path = require('path');
 const fs = require('fs-extra');
-const { runCli, runCliRepl, FIXTURE_DIR } = require('./helpers');
+const { runCli, runInConsole, FIXTURE_DIR } = require('./helpers');
 
 const cwd = FIXTURE_DIR;
 
 describe('tronbox console', function () {
-  this.timeout(60_000);
+  this.timeout(90_000);
 
   it('starts a REPL with the development network prompt and exits cleanly', () => {
     const r = runCli(['console'], { cwd, input: '.exit\n' });
@@ -60,11 +60,7 @@ describe('tronbox console', function () {
   });
 
   it('runs `test` from inside the REPL', async function () {
-    this.timeout(60_000);
-    const r = await runCliRepl(['console'], {
-      cwd,
-      steps: [{ input: 'test\n', expect: 'passing' }, { input: '.exit\n' }]
-    });
+    const r = await runInConsole('test', { cwd });
     expect(r.status, r.stderr).to.equal(0);
     expect(r.stdout).to.match(/\d+ passing/);
     expect(r.stdout).to.not.match(/\d+ failing/);

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -36,6 +36,21 @@ describe('tronbox console', function () {
     expect(r.stdout + r.stderr).to.match(/nosuchidentifier is not defined/);
   });
 
+  it('evaluates an expression and prints its value', async function () {
+    const r = await runInConsole('6 * 7', { cwd });
+    expect(r.status, r.stderr).to.equal(0);
+    expect(r.stdout).to.match(/> 42\b/);
+  });
+
+  it('exposes contract abstractions and the tronWeb instance in the REPL context', async function () {
+    expect(runCli(['compile'], { cwd }).status).to.equal(0);
+
+    const r = await runInConsole(['Migrations.contractName', 'typeof tronWeb'], { cwd });
+    expect(r.status, r.stderr).to.equal(0);
+    expect(r.stdout).to.include("'Migrations'");
+    expect(r.stdout).to.include("'object'");
+  });
+
   it('built-in `help` prints the command list', () => {
     const r = runCli(['console'], { cwd, input: 'help\n.exit\n' });
     expect(r.status, r.stderr).to.equal(0);
@@ -64,6 +79,12 @@ describe('tronbox console', function () {
     expect(r.status, r.stderr).to.equal(0);
     expect(r.stdout).to.match(/\d+ passing/);
     expect(r.stdout).to.not.match(/\d+ failing/);
+  });
+
+  it('rejects `test --network` when it differs from the REPL', () => {
+    const r = runCli(['console'], { cwd, input: 'test --network shasta\n.exit\n' });
+    expect(r.status, r.stderr).to.equal(0);
+    expect(r.stdout + r.stderr).to.include('the current REPL is using --network=development');
   });
 
   it('rejects `test --evm` from a non-EVM REPL', () => {

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -1,6 +1,8 @@
 // Requires TRE running on http://127.0.0.1:9090.
 
 const { expect } = require('chai');
+const path = require('path');
+const fs = require('fs-extra');
 const { runCli, runCliRepl, FIXTURE_DIR } = require('./helpers');
 
 const cwd = FIXTURE_DIR;
@@ -14,13 +16,18 @@ describe('tronbox console', function () {
     expect(r.stdout).to.include('tronbox(development)>');
   });
 
-  it('prints output from a console.log evaluated in the REPL', () => {
+  it('prints console.log output and records it in the history file', () => {
+    const historyFile = path.join(cwd, '.console_history');
+    fs.removeSync(historyFile);
     const r = runCli(['console'], {
       cwd,
-      input: 'console.log("hello-from-repl")\n.exit\n'
+      isTTY: true,
+      input: 'console.log("hello-from-repl")\n'
     });
     expect(r.status, r.stderr).to.equal(0);
-    expect(r.stdout).to.include('hello-from-repl');
+    // A terminal REPL echoes its input, so `include` would match the echo.
+    expect(r.stdout).to.match(/^hello-from-repl$/m);
+    expect(fs.readFileSync(historyFile, 'utf-8')).to.include('console.log("hello-from-repl")');
   });
 
   it('reports a ReferenceError for an unknown identifier', () => {

--- a/test/fixture/contracts_advanced/Empty.sol
+++ b/test/fixture/contracts_advanced/Empty.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+contract Empty {}

--- a/test/fixture/contracts_imports/Main.sol
+++ b/test/fixture/contracts_imports/Main.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.20;
 import './B.sol';
 import './utils/Math.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import 'sol-mock/Foo.sol';
+import 'sol-mock/Foo.sol'; // trailing comment
 
 contract Main {
   IERC20 public token;

--- a/test/fixture/migrations_advanced/1_deploy_contracts.js
+++ b/test/fixture/migrations_advanced/1_deploy_contracts.js
@@ -1,5 +1,5 @@
 const Roster = artifacts.require('./Roster.sol');
 
 module.exports = async function (deployer) {
-  await deployer.deploy(Roster, ['Tom', '30'], {});
+  await deployer.deploy(Roster, ['Tom', '30']);
 };

--- a/test/fixture/migrations_advanced/2_deploy_batch.js
+++ b/test/fixture/migrations_advanced/2_deploy_batch.js
@@ -1,0 +1,5 @@
+const Empty = artifacts.require('./Empty.sol');
+
+module.exports = async function (deployer) {
+  await deployer.deploy([Empty, Empty]);
+};

--- a/test/fixture/migrations_renumbered/1_initial_migration.js
+++ b/test/fixture/migrations_renumbered/1_initial_migration.js
@@ -1,0 +1,5 @@
+const Migrations = artifacts.require('./Migrations.sol');
+
+module.exports = async function (deployer) {
+  await deployer.deploy(Migrations);
+};

--- a/test/fixture/migrations_renumbered/3_deploy_contracts.js
+++ b/test/fixture/migrations_renumbered/3_deploy_contracts.js
@@ -1,0 +1,5 @@
+const Empty = artifacts.require('./Empty.sol');
+
+module.exports = async function (deployer) {
+  await deployer.deploy(Empty);
+};

--- a/test/fixture/tronbox-config.js
+++ b/test/fixture/tronbox-config.js
@@ -5,7 +5,7 @@
 //   MIGRATIONS_DIR    — switches migrations_directory (default: migrations)
 //   TEST_DIR          — switches test_directory (default: test)
 //   BUILD_DIR         — switches build_directory (default: build)
-//   SOLC_VERSION      — pins the Tron Solidity compiler version (default: 0.8.27)
+//   SOLC_VERSION      — pins the Tron Solidity compiler version (default: 0.8.28)
 //   SOLC_SETTINGS_JSON — JSON-encoded compilers.solc.settings (default: {})
 
 module.exports = {
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: process.env.SOLC_VERSION || '0.8.27',
+      version: process.env.SOLC_VERSION || '0.8.28',
       settings: process.env.SOLC_SETTINGS_JSON ? JSON.parse(process.env.SOLC_SETTINGS_JSON) : {}
     }
   }

--- a/test/fixture/tronbox-config.js
+++ b/test/fixture/tronbox-config.js
@@ -5,7 +5,7 @@
 //   MIGRATIONS_DIR    — switches migrations_directory (default: migrations)
 //   TEST_DIR          — switches test_directory (default: test)
 //   BUILD_DIR         — switches build_directory (default: build)
-//   SOLC_VERSION      — pins the Tron Solidity compiler version (default: 0.8.28)
+//   SOLC_VERSION      — pins the Tron Solidity compiler version (default: 0.8.29)
 //   SOLC_SETTINGS_JSON — JSON-encoded compilers.solc.settings (default: {})
 
 module.exports = {
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: process.env.SOLC_VERSION || '0.8.28',
+      version: process.env.SOLC_VERSION || '0.8.29',
       settings: process.env.SOLC_SETTINGS_JSON ? JSON.parse(process.env.SOLC_SETTINGS_JSON) : {}
     }
   }

--- a/test/fixture/tronbox-config.js
+++ b/test/fixture/tronbox-config.js
@@ -5,7 +5,7 @@
 //   MIGRATIONS_DIR    — switches migrations_directory (default: migrations)
 //   TEST_DIR          — switches test_directory (default: test)
 //   BUILD_DIR         — switches build_directory (default: build)
-//   SOLC_VERSION      — pins the Tron Solidity compiler version (default: 0.8.26)
+//   SOLC_VERSION      — pins the Tron Solidity compiler version (default: 0.8.27)
 //   SOLC_SETTINGS_JSON — JSON-encoded compilers.solc.settings (default: {})
 
 module.exports = {
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: process.env.SOLC_VERSION || '0.8.26',
+      version: process.env.SOLC_VERSION || '0.8.27',
       settings: process.env.SOLC_SETTINGS_JSON ? JSON.parse(process.env.SOLC_SETTINGS_JSON) : {}
     }
   }

--- a/test/fixture/tronbox-evm-config.js
+++ b/test/fixture/tronbox-evm-config.js
@@ -24,7 +24,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: process.env.SOLC_VERSION || '0.8.26',
+      version: process.env.SOLC_VERSION || '0.8.27',
       settings: {
         optimizer: {
           enabled: true,

--- a/test/fixture/tronbox-evm-config.js
+++ b/test/fixture/tronbox-evm-config.js
@@ -24,7 +24,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: process.env.SOLC_VERSION || '0.8.28',
+      version: process.env.SOLC_VERSION || '0.8.29',
       settings: {
         optimizer: {
           enabled: true,

--- a/test/fixture/tronbox-evm-config.js
+++ b/test/fixture/tronbox-evm-config.js
@@ -24,7 +24,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: process.env.SOLC_VERSION || '0.8.27',
+      version: process.env.SOLC_VERSION || '0.8.28',
       settings: {
         optimizer: {
           enabled: true,

--- a/test/flatten.test.js
+++ b/test/flatten.test.js
@@ -44,6 +44,9 @@ describe('tronbox flatten', function () {
       // No raw `import` directives should remain in the output.
       expect(r.stdout).to.not.match(/^\s*import\s+['"]/m);
 
+      // A trailing comment on an import must survive stripping.
+      expect(r.stdout).to.include('// trailing comment');
+
       // Single consolidated SPDX header at the top.
       const headers = r.stdout.match(/^\/\/ SPDX-License-Identifier:/gm) || [];
       expect(headers).to.have.lengthOf(1);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -24,50 +24,40 @@ function runCli(args, { cwd = FIXTURE_DIR, env = {}, input, timeout = 300_000, i
   });
 }
 
-// Drive the REPL line-by-line, only sending the next line once `expect` appears
-// in stdout. Required for any input that triggers a spawned subcommand —
-// spawnSync closes stdin on EOF, which makes the REPL exit and kill the child
-// before it can produce output.
-function runCliRepl(args, { cwd = FIXTURE_DIR, env = {}, steps = [], timeout = 180_000 } = {}) {
+// Run commands one at a time as the console prompt becomes ready, then exit.
+// Pass `bin` and optional `binArgs` to drive an installed tronbox instead of
+// the dev CLI.
+function runInConsole(commands, { cwd = FIXTURE_DIR, env = {}, timeout = 60_000, bin, binArgs = [] } = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [TRONBOX_BIN, ...args], {
-      cwd,
-      env: { ...process.env, ...env, FORCE_COLOR: '0' }
-    });
+    const spawnEnv = { ...process.env, ...env, FORCE_COLOR: '0' };
+    const child = bin
+      ? spawn(bin, [...binArgs, 'console'], { cwd, env: spawnEnv, shell: true })
+      : spawn(process.execPath, [TRONBOX_BIN, 'console'], { cwd, env: spawnEnv });
+    const pending = Array.isArray(commands) ? commands.slice() : [commands];
     let stdout = '';
     let stderr = '';
-    const pending = steps.slice();
-    let waitingFor = null;
-
-    const trySendNext = () => {
-      while (pending.length && (!waitingFor || stdout.includes(waitingFor))) {
-        const step = pending.shift();
-        waitingFor = step.expect || null;
-        child.stdin.write(step.input);
-      }
-      if (!pending.length && !waitingFor) child.stdin.end();
-    };
+    let handledPrompts = 0;
 
     child.stdout.on('data', d => {
       stdout += d.toString();
-      if (waitingFor && stdout.includes(waitingFor)) {
-        waitingFor = null;
-        trySendNext();
-      }
+      const promptCount = (stdout.match(/tronbox\([^)]+\)> /g) || []).length;
+      if (promptCount === handledPrompts) return;
+
+      handledPrompts = promptCount;
+      if (pending.length) child.stdin.write(`${pending.shift()}\n`);
+      else child.stdin.end('.exit\n');
     });
     child.stderr.on('data', d => (stderr += d.toString()));
 
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
-      reject(new Error(`runCliRepl timeout after ${timeout}ms\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      reject(new Error(`runInConsole timeout after ${timeout}ms\nstdout:\n${stdout}\nstderr:\n${stderr}`));
     }, timeout);
 
     child.on('close', (status, signal) => {
       clearTimeout(timer);
       resolve({ status, signal, stdout, stderr });
     });
-
-    trySendNext();
   });
 }
 
@@ -86,7 +76,7 @@ function removeTmp(dir) {
 
 module.exports = {
   runCli,
-  runCliRepl,
+  runInConsole,
   makeTmp,
   makeLocalTmp,
   removeTmp,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,8 +12,9 @@ const artifact = (buildDir, name) => path.join(buildDir, 'contracts', `${name}.j
 
 // Spawn the dev tronbox CLI. Default timeout exceeds the longest file-level
 // mocha timeout (300s) so a single CLI call never silently undercuts a test.
-function runCli(args, { cwd = FIXTURE_DIR, env = {}, input, timeout = 300_000 } = {}) {
-  return spawnSync(process.execPath, [TRONBOX_BIN, ...args], {
+function runCli(args, { cwd = FIXTURE_DIR, env = {}, input, timeout = 300_000, isTTY = false } = {}) {
+  const entry = isTTY ? ['-e', 'process.stdout.isTTY = true; require(process.argv[1]);'] : [];
+  return spawnSync(process.execPath, [...entry, TRONBOX_BIN, ...args], {
     cwd,
     encoding: 'utf-8',
     timeout,

--- a/test/meta.test.js
+++ b/test/meta.test.js
@@ -56,10 +56,12 @@ describe('tronbox CLI', function () {
   });
 
   describe('unknown command', () => {
-    it('exits non-zero with an "invalid command" error', () => {
-      const r = runCli(['nosuchcommand'], { cwd });
-      expect(r.status).to.not.equal(0);
-      expect(r.stderr).to.include('`tronbox nosuchcommand` is an invalid command');
+    ['nosuchcommand', 'toString', '__proto__'].forEach(name => {
+      it(`${name} exits non-zero as an invalid command`, () => {
+        const r = runCli([name], { cwd });
+        expect(r.status).to.not.equal(0);
+        expect(r.stderr).to.include(`\`tronbox ${name}\` is an invalid command`);
+      });
     });
   });
 });

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -64,6 +64,18 @@ describe('tronbox migrate', function () {
     });
   });
 
+  describe('renumbered migrations', () => {
+    it('runs a pending migration after the last completed one is renumbered', () => {
+      fs.removeSync(buildDir);
+      expect(runCli(['migrate'], { cwd }).status).to.equal(0);
+
+      const r = runCli(['migrate'], { cwd, env: { MIGRATIONS_DIR: 'migrations_renumbered' } });
+      expect(r.status, r.stderr).to.equal(0);
+      expect(r.stdout).to.include('Running migration: 3_deploy_contracts.js');
+      expect(r.stdout).to.not.include('Network up to date.');
+    });
+  });
+
   describe('without Migrations.sol', () => {
     const env = {
       CONTRACTS_DIR: 'contracts_no_migrations',

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -150,6 +150,25 @@ describe('tronbox migrate', function () {
     });
   });
 
+  describe('batch deploy', () => {
+    const env = {
+      CONTRACTS_DIR: 'contracts_advanced',
+      MIGRATIONS_DIR: 'migrations_advanced',
+      BUILD_DIR: 'build_advanced',
+      SOLC_VERSION: '0.8.20'
+    };
+    const altBuildDir = path.join(cwd, env.BUILD_DIR);
+
+    it('deploys each entry in an array to a distinct address', () => {
+      fs.removeSync(altBuildDir);
+      const r = runCli(['migrate'], { cwd, env });
+      expect(r.status, r.stderr).to.equal(0);
+      const addresses = [...r.stdout.matchAll(/Empty:\s+\(base58\) (\S+)/g)].map(m => m[1]);
+      expect(addresses).to.have.lengthOf(2);
+      expect(addresses[0]).to.not.equal(addresses[1]);
+    });
+  });
+
   describe('deploy alias', () => {
     it('behaves like migrate', () => {
       fs.removeSync(buildDir);

--- a/test/pack.test.js
+++ b/test/pack.test.js
@@ -44,41 +44,43 @@ describe('npm pack', function () {
 
   after(() => removeTmp(tmpPack));
 
-  it('ships every required directory and root file', () => {
-    const requiredRoots = ['build', 'sample-projects'];
-    const missingFromRequiredRoots = [];
+  describe('tarball contents', () => {
+    it('ships every required directory and root file', () => {
+      const requiredRoots = ['build', 'sample-projects'];
+      const missingFromRequiredRoots = [];
 
-    for (const root of requiredRoots) {
-      for (const f of walk(path.join(REPO_ROOT, root), root)) {
-        if (!packed.has(f)) missingFromRequiredRoots.push(f);
+      for (const root of requiredRoots) {
+        for (const f of walk(path.join(REPO_ROOT, root), root)) {
+          if (!packed.has(f)) missingFromRequiredRoots.push(f);
+        }
       }
-    }
 
-    expect(
-      missingFromRequiredRoots,
-      `npm pack is missing files under required directories:\n${missingFromRequiredRoots.join('\n')}`
-    ).to.be.empty;
+      expect(
+        missingFromRequiredRoots,
+        `npm pack is missing files under required directories:\n${missingFromRequiredRoots.join('\n')}`
+      ).to.be.empty;
 
-    const requiredRootFiles = ['console.sol', 'README.md', 'LICENSE'];
-    const missingRootFiles = requiredRootFiles.filter(f => !packed.has(f));
-    expect(missingRootFiles, `npm pack is missing required root files:\n${missingRootFiles.join('\n')}`).to.be.empty;
-  });
+      const requiredRootFiles = ['console.sol', 'README.md', 'LICENSE'];
+      const missingRootFiles = requiredRootFiles.filter(f => !packed.has(f));
+      expect(missingRootFiles, `npm pack is missing required root files:\n${missingRootFiles.join('\n')}`).to.be.empty;
+    });
 
-  it('keeps build/ aligned with src/', () => {
-    const srcFiles = new Set(walk(path.join(REPO_ROOT, 'src')));
-    const buildFiles = new Set(walk(path.join(REPO_ROOT, 'build')));
-    const allowedExtras = new Set(['tronbox.js']);
+    it('keeps build/ aligned with src/', () => {
+      const srcFiles = new Set(walk(path.join(REPO_ROOT, 'src')));
+      const buildFiles = new Set(walk(path.join(REPO_ROOT, 'build')));
+      const allowedExtras = new Set(['tronbox.js']);
 
-    const missing = [...srcFiles].filter(f => !buildFiles.has(f));
-    const extra = [...buildFiles].filter(f => !srcFiles.has(f) && !allowedExtras.has(f));
+      const missing = [...srcFiles].filter(f => !buildFiles.has(f));
+      const extra = [...buildFiles].filter(f => !srcFiles.has(f) && !allowedExtras.has(f));
 
-    const lines = [];
-    if (missing.length)
-      lines.push(`files present in src/ but missing in build/:\n${missing.map(f => `  - ${f}`).join('\n')}`);
-    if (extra.length)
-      lines.push(`unexpected files in build/ without a src/ counterpart:\n${extra.map(f => `  + ${f}`).join('\n')}`);
+      const lines = [];
+      if (missing.length)
+        lines.push(`files present in src/ but missing in build/:\n${missing.map(f => `  - ${f}`).join('\n')}`);
+      if (extra.length)
+        lines.push(`unexpected files in build/ without a src/ counterpart:\n${extra.map(f => `  + ${f}`).join('\n')}`);
 
-    expect(lines.length, `build/ and src/ are out of sync:\n${lines.join('\n')}`).to.equal(0);
+      expect(lines.length, `build/ and src/ are out of sync:\n${lines.join('\n')}`).to.equal(0);
+    });
   });
 
   describe('end-to-end checks with an installed package tarball', function () {

--- a/test/pack.test.js
+++ b/test/pack.test.js
@@ -1,10 +1,14 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { expect } = require('chai');
-const { REPO_ROOT, makeTmp, removeTmp } = require('./helpers');
+const { REPO_ROOT, makeTmp, makeLocalTmp, removeTmp, runInConsole } = require('./helpers');
 
 const ALWAYS_SKIP = new Set(['.git', 'node_modules', '.DS_Store']);
+
+// Cap for every spawned command; kills a hung child with its output captured,
+// well before the file-level mocha timeout reports.
+const COMMAND_TIMEOUT = 300_000;
 
 function walk(dir, prefix = '') {
   const out = [];
@@ -26,12 +30,11 @@ describe('npm pack', function () {
   let packed;
 
   before(function () {
-    this.timeout(180_000);
     tmpPack = makeTmp('tronbox-pack-tarball-');
     const r = spawnSync('npm', ['pack', '--pack-destination', tmpPack, '--json'], {
       cwd: REPO_ROOT,
       encoding: 'utf-8',
-      timeout: 180_000,
+      timeout: COMMAND_TIMEOUT,
       shell: true
     });
     if (r.status !== 0) throw new Error(`npm pack failed: ${r.stderr}`);
@@ -83,101 +86,185 @@ describe('npm pack', function () {
     });
   });
 
-  describe('end-to-end checks with an installed package tarball', function () {
-    this.timeout(600_000);
+  function installedPackageChecks(name, install) {
+    describe(name, function () {
+      let root;
+      let cli;
 
-    let tmpInstall;
-    let packedBin;
-
-    before(function () {
-      this.timeout(480_000);
-      tmpInstall = makeTmp('tronbox-pack-install-');
-      fs.writeFileSync(
-        path.join(tmpInstall, 'package.json'),
-        JSON.stringify({ name: 'tronbox-pack-host', private: true })
-      );
-      const install = spawnSync('npm', ['install', '--no-audit', '--no-fund', '--no-progress', tarball], {
-        cwd: tmpInstall,
-        encoding: 'utf-8',
-        timeout: 480_000,
-        shell: true
+      before(function () {
+        // Keep the install root outside os.tmpdir so executable paths use the
+        // same spelling on macOS instead of mixing /var and /private/var.
+        root = makeLocalTmp('tronbox-pack-install-');
+        cli = { root, ...install.call(this, root) };
       });
-      if (install.status !== 0)
-        throw new Error(`npm install of packed tarball failed: ${install.stderr}\n${install.stdout}`);
 
-      packedBin = path.join(tmpInstall, 'node_modules', '.bin', 'tronbox');
-      if (!fs.existsSync(packedBin)) throw new Error(`installed tronbox binary is missing at ${packedBin}`);
+      after(() => removeTmp(root));
+
+      function run(args, { cwd, env = {} } = {}) {
+        return spawnSync(cli.bin, [...cli.binArgs, ...args], {
+          cwd,
+          encoding: 'utf-8',
+          timeout: COMMAND_TIMEOUT,
+          shell: true,
+          env: { ...process.env, ...cli.env, ...env, FORCE_COLOR: '0' }
+        });
+      }
+
+      function expectTestsToPass(r) {
+        expect(r.status, r.stderr).to.equal(0);
+        expect(r.stdout).to.include("Using network 'development'");
+        expect(r.stdout).to.include('Contract: MetaCoin');
+        expect(r.stdout).to.match(/\d+ passing/);
+        expect(r.stdout).to.not.match(/\d+ failing/);
+      }
+
+      describe('project created by tronbox init', function () {
+        let project;
+
+        before(function () {
+          project = path.join(cli.root, 'projects', 'metacoin');
+          fs.mkdirSync(project, { recursive: true });
+          const r = run(['init'], {
+            cwd: project,
+            env: { TRONBOX_CREATE_JAVASCRIPT_METACOIN_PROJECT_WITH_DEFAULTS: 'true' }
+          });
+          expect(r.status, r.stderr).to.equal(0);
+          expect(fs.existsSync(path.join(project, 'contracts', 'MetaCoin.sol'))).to.equal(true);
+          expect(fs.existsSync(path.join(project, 'node_modules', 'tronbox'))).to.equal(false);
+        });
+
+        it('compiles and writes the contract artifacts', () => {
+          const r = run(['compile'], { cwd: project });
+          expect(r.status, r.stderr).to.equal(0);
+          expect(r.stdout).to.include('Compiled successfully');
+          expect(fs.existsSync(path.join(project, 'build', 'contracts', 'MetaCoin.json'))).to.equal(true);
+        });
+
+        it('downloads the configured compiler when the cache is empty', () => {
+          fs.removeSync(path.join(project, 'build'));
+          const tmpHome = makeTmp('tronbox-pack-home-');
+          try {
+            const r = run(['compile'], { cwd: project, env: { HOME: tmpHome, USERPROFILE: tmpHome } });
+            expect(r.status, r.stderr).to.equal(0);
+            expect(r.stdout).to.include('Fetching Tron Solidity compiler version');
+            expect(r.stdout).to.include('Compiled successfully');
+          } finally {
+            removeTmp(tmpHome);
+          }
+        });
+
+        it('migrates against the development network', () => {
+          const r = run(['migrate'], { cwd: project });
+          expect(r.status, r.stderr).to.equal(0);
+          expect(r.stdout).to.include("Using network 'development'");
+          expect(r.stdout).to.include('Running migration: 1_initial_migration.js');
+          expect(r.stdout).to.include('Running migration: 2_deploy_contracts.js');
+          expect(r.stdout).to.include('Deploying MetaCoin');
+        });
+
+        it('runs the contract tests', () => {
+          expectTestsToPass(run(['test'], { cwd: project }));
+        });
+
+        it('runs the contract tests from inside the console', async () => {
+          const r = await runInConsole('test', {
+            bin: cli.bin,
+            binArgs: cli.binArgs,
+            cwd: project,
+            env: cli.env,
+            timeout: COMMAND_TIMEOUT
+          });
+          expectTestsToPass(r);
+        });
+
+        it('flattens the contract into fully inlined source', () => {
+          const r = run(['flatten', 'contracts/MetaCoin.sol'], { cwd: project });
+          expect(r.status, r.stderr).to.equal(0);
+          expect(r.stdout).to.match(/^\/\/ Sources flattened with TronBox v\d+\.\d+\.\d+/);
+          expect(r.stdout).to.include('// File contracts/MetaCoin.sol');
+          expect(r.stdout).to.include('@openzeppelin/contracts');
+          expect(r.stdout).to.not.match(/^\s*import\s+['"]/m);
+        });
+      });
+
+      describe('unboxed project', function () {
+        let project;
+
+        before(function () {
+          project = path.join(cli.root, 'projects', 'unboxed-metacoin');
+          fs.mkdirSync(project, { recursive: true });
+          const r = run(['unbox', 'metacoin-box'], { cwd: project });
+          expect(r.status, r.stderr).to.equal(0);
+          expect(r.stdout).to.include('Unbox successful');
+        });
+
+        it('runs the unboxed contract tests', () => {
+          expectTestsToPass(run(['test'], { cwd: project }));
+        });
+      });
     });
+  }
 
-    after(() => removeTmp(tmpInstall));
+  installedPackageChecks('locally installed tarball via npx --no-install tronbox', root => {
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'tronbox-pack-host', private: true }));
+    const install = spawnSync('npm', ['install', '--no-audit', '--no-fund', '--no-progress', tarball], {
+      cwd: root,
+      encoding: 'utf-8',
+      timeout: COMMAND_TIMEOUT,
+      shell: true
+    });
+    if (install.status !== 0)
+      throw new Error(`npm install of packed tarball failed: ${install.stderr}\n${install.stdout}`);
 
-    function runPacked(args, { cwd, env = {}, timeout = 300_000 } = {}) {
-      return spawnSync(packedBin, args, {
-        cwd,
+    const localBin = path.join(root, 'node_modules', '.bin', 'tronbox');
+    if (!fs.existsSync(localBin)) throw new Error(`installed tronbox binary is missing at ${localBin}`);
+
+    return { bin: 'npx', binArgs: ['--no-install', 'tronbox'], env: {} };
+  });
+
+  installedPackageChecks('globally installed tarball via tronbox on PATH', function (root) {
+    if (process.platform === 'win32') this.skip();
+    const install = spawnSync(
+      'npm',
+      ['install', '-g', '--prefix', root, '--no-audit', '--no-fund', '--no-progress', tarball],
+      {
         encoding: 'utf-8',
-        timeout,
-        shell: true,
-        env: { ...process.env, ...env, FORCE_COLOR: '0' }
-      });
+        timeout: COMMAND_TIMEOUT,
+        shell: true
+      }
+    );
+    if (install.status !== 0)
+      throw new Error(`global npm install of packed tarball failed: ${install.stderr}\n${install.stdout}`);
+
+    const globalBin = path.join(root, 'bin');
+    const isolatedNode = path.join(globalBin, path.basename(process.execPath));
+    // Reproduce a global install where the package shim sits beside Node. A
+    // symlink is insufficient because process.execPath resolves through it.
+    try {
+      fs.linkSync(process.execPath, isolatedNode);
+    } catch (error) {
+      if (!['EACCES', 'EMLINK', 'ENOTSUP', 'EPERM', 'EXDEV'].includes(error.code)) throw error;
+      fs.copyFileSync(process.execPath, isolatedNode);
+      fs.chmodSync(isolatedNode, fs.statSync(process.execPath).mode & 0o777);
     }
 
-    describe('after running tronbox init', () => {
-      let tmp;
-
-      before(function () {
-        this.timeout(600_000);
-        tmp = makeTmp('tronbox-pack-init-');
-        const r = runPacked(['init'], {
-          cwd: tmp,
-          env: { TRONBOX_CREATE_JAVASCRIPT_METACOIN_PROJECT_WITH_DEFAULTS: 'true' },
-          timeout: 480_000
-        });
-        expect(r.status, r.stderr).to.equal(0);
-        expect(fs.existsSync(path.join(tmp, 'contracts', 'MetaCoin.sol'))).to.equal(true);
-      });
-
-      after(() => removeTmp(tmp));
-
-      it('runs tronbox test successfully', () => {
-        const r = runPacked(['test'], { cwd: tmp });
-        expect(r.status, r.stderr).to.equal(0);
-        expect(r.stdout).to.include("Using network 'development'");
-        expect(r.stdout).to.include('Contract: MetaCoin');
-        expect(r.stdout).to.match(/\d+ passing/);
-        expect(r.stdout).to.not.match(/\d+ failing/);
-      });
-
-      it('runs tronbox flatten and outputs fully inlined sources', () => {
-        const r = runPacked(['flatten', 'contracts/MetaCoin.sol'], { cwd: tmp });
-        expect(r.status, r.stderr).to.equal(0);
-        expect(r.stdout).to.match(/^\/\/ Sources flattened with TronBox v\d+\.\d+\.\d+/);
-        expect(r.stdout).to.include('// File contracts/MetaCoin.sol');
-        expect(r.stdout).to.include('@openzeppelin/contracts');
-        expect(r.stdout).to.not.match(/^\s*import\s+['"]/m);
-      });
+    const env = { PATH: globalBin + path.delimiter + process.env.PATH };
+    const resolved = spawnSync('command -v tronbox', {
+      encoding: 'utf-8',
+      shell: true,
+      env: { ...process.env, ...env }
     });
+    expect(resolved.status, resolved.stderr).to.equal(0);
+    expect(resolved.stdout.trim()).to.equal(path.join(globalBin, 'tronbox'));
 
-    describe('after running tronbox unbox', () => {
-      let tmp;
-
-      before(function () {
-        this.timeout(480_000);
-        tmp = makeTmp('tronbox-pack-unbox-');
-        const r = runPacked(['unbox', 'metacoin-box'], { cwd: tmp, timeout: 480_000 });
-        expect(r.status, r.stderr).to.equal(0);
-        expect(r.stdout).to.include('Unbox successful');
-      });
-
-      after(() => removeTmp(tmp));
-
-      it('runs tronbox test successfully', () => {
-        const r = runPacked(['test'], { cwd: tmp });
-        expect(r.status, r.stderr).to.equal(0);
-        expect(r.stdout).to.include("Using network 'development'");
-        expect(r.stdout).to.include('Contract: MetaCoin');
-        expect(r.stdout).to.match(/\d+ passing/);
-        expect(r.stdout).to.not.match(/\d+ failing/);
-      });
+    const nodeProbe = spawnSync('node', ['-p', 'process.execPath'], {
+      encoding: 'utf-8',
+      shell: true,
+      env: { ...process.env, ...env }
     });
+    expect(nodeProbe.status, nodeProbe.stderr).to.equal(0);
+    expect(nodeProbe.stdout.trim()).to.equal(isolatedNode);
+
+    return { bin: 'tronbox', binArgs: [], env };
   });
 });


### PR DESCRIPTION
**4.10.0**

### Features

- Added support for Tron Solidity compilers 0.8.27, 0.8.28 and 0.8.29; new projects default to 0.8.29
- `console` now persists REPL history across sessions in `.console_history` under the project root

### Bug Fixes

- Fixed `migrate` skipping pending migrations when the last completed migration file has been renumbered or removed
- Fixed array-form `deployer.deploy` deploying contracts concurrently instead of sequentially
- Fixed transaction option handling when deploying and calling contracts
- Fixed `test` dropping user-configured mocha `reporterOptions`
- Fixed `console` ignoring artifact-loading errors; it now loads only `.json` artifacts and exits on a corrupt one
- Fixed `flatten` duplicating sources included through different import paths
- Fixed `flatten` dropping trailing content when stripping import lines
- Fixed `unbox` masking download and extraction errors
- Fixed calling contract functions named `name` or `length` on deployed contract instances
- Fixed unknown commands that match built-in JavaScript property names not being rejected

### Dependencies

- Upgraded `tronweb` to 6.4.0
- Upgraded `axios` to 1.19.0
